### PR TITLE
Fix YAML configuration examples in documentation

### DIFF
--- a/docs/en/notes/guide/mixer/quickstart.md
+++ b/docs/en/notes/guide/mixer/quickstart.md
@@ -23,6 +23,4 @@ component_name: random
 warmup_step: 100
 update_step: 200
 update_times: 3
-
-eval_dataset: mmlu_eval
 ```

--- a/docs/en/notes/guide/weighter/quickstart.md
+++ b/docs/en/notes/guide/weighter/quickstart.md
@@ -17,10 +17,9 @@ Unlike vanilla LlamaFactory, your `.yaml` config file must include **DataFlex-sp
 
 ```yaml
 ### dynamic_train
-train_type: dynamic_weight
+train_type: dynamic_weight 
 components_cfg_file: src/dataflex/configs/components.yaml
 component_name: loss
-warmup_step: 200
-update_step: 400
-update_times: 5
+warmup_step: 1
+train_step: 3 # total train steps (including warmup)
 ```

--- a/docs/zh/notes/guide/mixer/quickstart.md
+++ b/docs/zh/notes/guide/mixer/quickstart.md
@@ -23,6 +23,4 @@ component_name: random
 warmup_step: 100
 update_step: 200
 update_times: 3
-
-eval_dataset: mmlu_eval
 ```

--- a/docs/zh/notes/guide/weighter/quickstart.md
+++ b/docs/zh/notes/guide/weighter/quickstart.md
@@ -17,10 +17,9 @@ FORCE_TORCHRUN=1 DISABLE_VERSION_CHECK=1 dataflex-cli train examples/train_lora/
 
 ```yaml
 ### dynamic_train
-train_type: dynamic_weight
+train_type: dynamic_weight 
 components_cfg_file: src/dataflex/configs/components.yaml
 component_name: loss
-warmup_step: 200
-update_step: 400
-update_times: 5
+warmup_step: 1
+train_step: 3 # 总训练步数（包括warm_up） 
 ```


### PR DESCRIPTION
- Fix YAML syntax errors in mixer and weighter quickstart guides
- Update configuration examples for both English and Chinese docs
- Ensure consistency with actual YAML schema requirements